### PR TITLE
Add plans step

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,16 @@ Following that, we'll need to install all composer dependencies through the foll
 ```php
 composer install
 ```
-### 4. Run Migrations and Seeds
+
+### 4. Update plans
+
+We then update the plans to be created as per your Paddle account. 
+
+To create plans, navigate to Catalogue » [Subscription Plans](https://sandbox-vendors.paddle.com/subscriptions/plans) on your Paddle account.
+
+Update the `plan_id`, `price`, `trial_days`, etc. in the plans array in [PlansTableSeeder](database/seeders/PlansTableSeeder.php)
+
+### 5. Run Migrations and Seeds
 
 We must migrate our database schema into our database, which we can accomplish by running the following command:
 


### PR DESCRIPTION
It looks pretty obvious that one should update the plans before seeding but I suspect there would still be users who will will spend 20 minutes wondering why they are receiving the following while attempting to checkout.

```json
{"success":false,"error":{"code":107,"message":"You don't have permission to access this resource"}}
```